### PR TITLE
Add HAVE_CYTHON flag in case Cython is not installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,8 @@ except ImportError as e:
     warnings.warn(e.message)
     from setuptools import setup, Extension
     from setuptools.command.build_ext import build_ext
+    HAVE_CYTHON = False
+
 import numpy
 
 _hdbscan_tree = Extension('hdbscan._hdbscan_tree',


### PR DESCRIPTION
Just a small change that sets the `HAVE_CYTHON` flag to `False` in case it is not installed on the end user's machine.