### PR TITLE
Fixed README.rst link to "Python vs Java"-notebook in nbviewer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ Performance
 -----------
 
 Significant effort has been put into making the hdbscan implementation as fast as 
-possible. It is `orders of magnitude faster than the reference implementation <https://nbviewerjupyter.org/github/lmcinnes/hdbscan/blobmaster/notebooks/Python%20vs%20Java.ipynb>`_ in Java,
+possible. It is `orders of magnitude faster than the reference implementation <http://nbviewer.jupyter.org/github/lmcinnes/hdbscan/blob/master/notebooks/Python%20vs%20Java.ipynb>`_ in Java,
 and is currently faster than highly optimized single linkage implementations in C and C++.
 `version 0.6 performance can be seen in this notebook <http://nbviewer.jupyter.org/github/lmcinnes/hdbscan/blob/master/notebooks/Benchmarking%20scalability%20of%20clustering%20implementations-v0.6.ipynb>`_ .
 In particular `performance on low dimensional data is better than sklearn's DBSCAN <http://nbviewer.jupyter.org/github/lmcinnes/hdbscan/blob/master/notebooks/Benchmarking%20scalability%20of%20clustering%20implementations%202D%20v0.6.ipynb>`_ ,


### PR DESCRIPTION
Fixed broken link in README – it's a tiny contribution, but a contribution nonetheless :)